### PR TITLE
Native lib resolves with System.Reflection.Metadata

### DIFF
--- a/Simbolo.Backend/Symbolicate.cs
+++ b/Simbolo.Backend/Symbolicate.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Pdb;
+using Simbolo.StackFrameData;
 using SequencePoint = Mono.Cecil.Cil.SequencePoint;
 
 namespace Simbolo.Backend
@@ -13,57 +15,78 @@ namespace Simbolo.Backend
         // symbols should be cached in memory with LRU with mvid as key
         public static Location? SymbolicateFrame(string symbolsPath, FrameInfo frame)
         {
-            var path = symbolsPath;
-            var rp = new ReaderParameters
+            using var s = new SymbolicateStackTrace(new SymbolicateOptions
             {
-                ReadSymbols = true,
-                SymbolReaderProvider = new PdbReaderProvider()
-            };
-
-            var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(path, rp);
-            var module = assemblyDefinition.Modules.FirstOrDefault(m => m.Mvid == frame.Mvid);
-            if (module is null)
-            {
-                Console.WriteLine($"Can't find a module with id {frame.Mvid} in {assemblyDefinition.Name}");
-                return null;
-            }
-            if (!module.HasSymbols)
-            {
-                Console.WriteLine($"Module {module.Mvid} does not have symbols");
-                return null;
-            }
-
-            // TODO: Account for sub types
-            var method = module.Types.SelectMany(t => t.Methods).FirstOrDefault(m => m.Name == frame.Method);
-            if (method is null)
-            {
-                return null;
-            }
-            // TODO: Check signature to find overload
-
-            SequencePoint sequencePoint = null!;
-            foreach (var sp in method
-                .DebugInformation
-                .SequencePoints
-                .OrderBy(s => s.Offset))
-            {
-                sequencePoint = sp;
-                if (sp.Offset >= frame.ILOffset)
+                // SymbolsPath = Path.GetFullPath(symbolsPath)
+            });
+            var frameInfo = new StackFrameInformation(
+                null,
+                frame.ILOffset,
+                null,
+                frame.ILOffset,
+                frame.Mvid,
+                true,
+                null, null, null, null, null);
+            var info = new StackTraceInformation(new[] {frameInfo},
+                new Dictionary<Guid, DebugMeta>
                 {
-                    break;
-                }
-            }
+                    {frame.Mvid, new DebugMeta(symbolsPath, frame.Mvid, "ppdb", frame.Mvid, 1, null)}
+                });
 
-            if (sequencePoint is null)
-            {
-                throw new InvalidOperationException("No sequence point was found for offset: " + frame.ILOffset);
-            }
-            var location = new Location(
-                sequencePoint.Document.Url,
-                sequencePoint.StartLine,
-                sequencePoint.StartColumn);
-
-            return location;
+            s.Symbolicate(info);
+            return new Location(frameInfo.FileName!, frameInfo.LineNumber!.Value, frameInfo.ColumnNumber!.Value);
+            //
+            // var path = symbolsPath;
+            // var rp = new ReaderParameters
+            // {
+            //     ReadSymbols = true,
+            //     SymbolReaderProvider = new PdbReaderProvider()
+            // };
+            //
+            // var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(path, rp);
+            // var module = assemblyDefinition.Modules.FirstOrDefault(m => m.Mvid == frame.Mvid);
+            // if (module is null)
+            // {
+            //     Console.WriteLine($"Can't find a module with id {frame.Mvid} in {assemblyDefinition.Name}");
+            //     return null;
+            // }
+            // if (!module.HasSymbols)
+            // {
+            //     Console.WriteLine($"Module {module.Mvid} does not have symbols");
+            //     return null;
+            // }
+            //
+            // // TODO: Account for sub types
+            // var method = module.Types.SelectMany(t => t.Methods).FirstOrDefault(m => m.Name == frame.Method);
+            // if (method is null)
+            // {
+            //     return null;
+            // }
+            // // TODO: Check signature to find overload
+            //
+            // SequencePoint sequencePoint = null!;
+            // foreach (var sp in method
+            //     .DebugInformation
+            //     .SequencePoints
+            //     .OrderBy(s => s.Offset))
+            // {
+            //     sequencePoint = sp;
+            //     if (sp.Offset >= frame.ILOffset)
+            //     {
+            //         break;
+            //     }
+            // }
+            //
+            // if (sequencePoint is null)
+            // {
+            //     throw new InvalidOperationException("No sequence point was found for offset: " + frame.ILOffset);
+            // }
+            // var location = new Location(
+            //     sequencePoint.Document.Url,
+            //     sequencePoint.StartLine,
+            //     sequencePoint.StartColumn);
+            //
+            // return location;
         }
 
         public static IEnumerable<Location?> SymbolicateFrames(string symbolsPath, IEnumerable<FrameInfo> frames)

--- a/Simbolo.Backend/SymbolicateStackTrace.cs
+++ b/Simbolo.Backend/SymbolicateStackTrace.cs
@@ -41,7 +41,7 @@ namespace Simbolo.Backend
                 } 
                 else
                 {
-                    info.StackFrameInformation[i] = stackFrameInformation;    
+                    info.StackFrameInformation[i] = stackFrameInformation;
                 }
             }
         }
@@ -69,26 +69,26 @@ namespace Simbolo.Backend
 
             IEnumerable<string> GetProbingPaths()
             {
+                var file = Path.ChangeExtension(debugMeta.File, "pdb");
+
                 if (_options.SymbolsPath is { } path)
                 {
+                    var fileName = Path.GetFileName(file);
+
                     // File under a folder named after the mvid
                     yield return Path.Combine(
                         path,
                         // mono builds moves the pdb/dll under a folder named with the mvid
                         debugMeta.ModuleId.ToString("n"),
-                        Path.ChangeExtension(Path.GetFileName(debugMeta.File),
-                            "pdb"));
+                        fileName);
 
                     // File directly in the symbols path
-                    yield return Path.Combine(
-                        path,
-                        Path.ChangeExtension(Path.GetFileName(debugMeta.File),
-                            "pdb"));
+                    yield return Path.Combine(path, fileName);
                 }
 
                 if (_options.AttemptOriginalSymbolPath)
                 {
-                    yield return debugMeta.File;
+                    yield return file;
                 }
             }
 
@@ -98,6 +98,7 @@ namespace Simbolo.Backend
                 {
                     try
                     {
+                        Console.WriteLine("probingPath: " + probingPath);
                         return File.OpenRead(probingPath);
                     }
                     catch// (Exception e)
@@ -110,6 +111,7 @@ namespace Simbolo.Backend
                 var fileStream = SafeGetFileStream();
                 if (fileStream is not null)
                 {
+                    Console.WriteLine("Opening file at: " + ((FileStream) fileStream).Name);
                     var provider = MetadataReaderProvider.FromPortablePdbStream(fileStream);
                     var reader = provider.GetMetadataReader();
                     // Standalone debug metadata image doesn't contain Module table.

--- a/Simbolo.Backend/SymbolicateStackTrace.cs
+++ b/Simbolo.Backend/SymbolicateStackTrace.cs
@@ -161,7 +161,10 @@ namespace Simbolo.Backend
         {
             var methodToken = MetadataTokens.Handle(token);
 
-            Debug.Assert(methodToken.Kind == HandleKind.MethodDefinition);
+            if (methodToken.Kind != HandleKind.MethodDefinition)
+            {
+                return null;
+            }
 
             var handle = ((MethodDefinitionHandle)methodToken).ToDebugInformationHandle();
             

--- a/Simbolo.Tests/SymbolicateStackTraceTests.cs
+++ b/Simbolo.Tests/SymbolicateStackTraceTests.cs
@@ -36,7 +36,7 @@ namespace Simbolo.Tests
             {
                 info = Client.GetStackTraceInformation(e);
             }
-            
+
             // The Simbolo.dll frames and also System.Private.CoreLib.pdb
             // Test lib isn't listed because line numbers are already available (pdb was found)
             Assert.Equal(2, info.DebugMetas.Count);
@@ -56,9 +56,9 @@ namespace Simbolo.Tests
                 && i.LineNumber is not null
                 && i.ColumnNumber is not null
                 && i.FileName is not null));
-            
+
             // Symbolicate the frames:
-            
+
             // Test symbolication
             _fixture.Options.SymbolsPath = pdbPath;
 
@@ -70,7 +70,7 @@ namespace Simbolo.Tests
             sut.Symbolicate(info);
 
             var simboloFrames = info.StackFrameInformation.Where(f => f.Mvid == simbolo.Key).ToArray();
-            // number of frames will change only if Example.cs changes 
+            // number of frames will change only if Example.cs changes
             const int exampleFrames = 24;
             Assert.Equal(exampleFrames, simboloFrames.Length);
             Assert.Equal(exampleFrames, simboloFrames.Count(f => f.LineNumber is not null));


### PR DESCRIPTION
```
Unhandled Exception: System.InvalidCastException: Specified cast is not valid.
   at System.Reflection.Throw.InvalidCast() + 0x20
   at System.Reflection.Metadata.MethodDefinitionHandle.op_Explicit(Handle) + 0x11
   at Simbolo.Backend.SymbolicateStackTrace.GetLineColumnFile(MetadataReader, Int32, Int32) + 0x75
   at Simbolo.Backend.SymbolicateStackTrace.GetNewStackFrameInformation(StackFrameInformation, MetadataReader) + 0x5d
   at Simbolo.Backend.SymbolicateStackTrace.Symbolicate(StackTraceInformation) + 0xea
   at Simbolo.Backend.Symbolicate.SymbolicateFrame(String, FrameInfo) + 0x299
   at Simbolo.NativeLib!<BaseAddress>+0x134026
./run.sh: line 19: 26649 Abort trap: 6           ./app $simboloPath ${parts[0]} ${parts[2]} ${parts[1]} ${parts[3]}

```